### PR TITLE
📝 Specify Python language for README's codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Snippets and examples for potential uses within After Effects
 
 ### Working with projects
 
-```
+```python
 app = pydobe.objects.app
 
 # Open a Project
@@ -62,7 +62,7 @@ app.new_project()  # This will display a user prompt
 
 ### Working with items
 
-```
+```python
 project = pydobe.objects.app.project
 
 # Check how many items are in the project
@@ -99,7 +99,7 @@ for child in footage_folder.items:
 
 ### Adding items to a project
 
-```
+```python
 project = pydobe.objects.app.project
 
 # Create some folders


### PR DESCRIPTION
Hi!

I just added `python` to the codeblocks so it gets the right syntax highlighting.